### PR TITLE
Allow spanable text on tooltip.

### DIFF
--- a/app/src/main/java/com/tomergoldst/tooltipsdemo/MainActivity.java
+++ b/app/src/main/java/com/tomergoldst/tooltipsdemo/MainActivity.java
@@ -16,10 +16,12 @@ limitations under the License.
 
 package com.tomergoldst.tooltipsdemo;
 
+import android.graphics.Color;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.design.widget.TextInputEditText;
 import android.support.v7.app.AppCompatActivity;
+import android.text.Html;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Gravity;
@@ -127,8 +129,15 @@ public class MainActivity extends AppCompatActivity implements
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
 
-        ToolTip.Builder builder = new ToolTip.Builder(this, mTextView, mRootLayout, TIP_TEXT, ToolTip.POSITION_ABOVE);
+        // This tip is shows the first time the sample app is loaded. Use a message that gives user
+        // guide on how to use the sample app. Also try to showcase the ability of the app.
+        CharSequence initialGuideTex = Html.fromHtml("Click on the <a href='#'>Buttons</a> " +
+                "and the <a href='#'>Radio Buttons</a> bellow to test various tool tip configurations." +
+                "<br><br><font color='grey'><small>GOT IT</small></font>");
+
+        ToolTip.Builder builder = new ToolTip.Builder(this, mTextView, mRootLayout, initialGuideTex, ToolTip.POSITION_ABOVE);
         builder.setAlign(mAlign);
+        builder.setBackgroundColor(Color.DKGRAY);
         builder.setTextAppearance(R.style.TooltipTextAppearance);
         mToolTipsManager.show(builder.build());
     }

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -23,6 +23,7 @@
     -->
     <style name="TooltipTextAppearance">
         <item name="android:textColor">@android:color/white</item>
+        <item name="android:textColorLink">@android:color/holo_blue_light</item>
         <item name="android:textSize">16sp</item>
         <item name="android:textStyle">bold</item>
     </style>

--- a/tooltips/src/main/java/com/tomergoldst/tooltips/ToolTip.java
+++ b/tooltips/src/main/java/com/tomergoldst/tooltips/ToolTip.java
@@ -19,9 +19,9 @@ package com.tomergoldst.tooltips;
 import android.content.Context;
 import android.graphics.Typeface;
 import android.support.annotation.IntDef;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StyleRes;
-import android.text.Spannable;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -51,10 +51,10 @@ public class ToolTip {
     public static final int GRAVITY_LEFT = 1;
     public static final int GRAVITY_RIGHT = 2;
 
-    private Context mContext;
-    private View mAnchorView;
-    private ViewGroup mRootViewGroup;
-    private String mMessage;
+    private @NonNull Context mContext;
+    private @NonNull View mAnchorView;
+    private @NonNull ViewGroup mRootViewGroup;
+    private @NonNull CharSequence mMessage;
     private @Position int mPosition;
     private @Align int mAlign;
     private int mOffsetX;
@@ -63,9 +63,8 @@ public class ToolTip {
     private int mBackgroundColor;
     private float mElevation;
     private @Gravity int mTextGravity;
-    private Spannable mSpannableMessage;
     private @StyleRes int mTextAppearanceStyle;
-    private Typeface mTypeface;
+    private @Nullable Typeface mTypeface;
 
     public ToolTip(Builder builder){
         mContext = builder.mContext;
@@ -81,24 +80,27 @@ public class ToolTip {
         mBackgroundColor = builder.mBackgroundColor;
         mElevation = builder.mElevation;
         mTextGravity = builder.mTextGravity;
-        mSpannableMessage = builder.mSpannableMessage;
         mTextAppearanceStyle = builder.mTextAppearanceStyle;
         mTypeface = builder.mTypeface;
     }
 
+    @NonNull
     public Context getContext() {
         return mContext;
     }
 
+    @NonNull
     public View getAnchorView() {
         return mAnchorView;
     }
 
+    @NonNull
     public ViewGroup getRootView() {
         return mRootViewGroup;
     }
 
-    public String getMessage() {
+    @NonNull
+    public CharSequence getMessage() {
         return mMessage;
     }
 
@@ -172,6 +174,7 @@ public class ToolTip {
         return mTypeface;
     }
 
+    @NonNull
     public int getTextGravity(){
         int gravity;
         switch (mTextGravity){
@@ -190,15 +193,11 @@ public class ToolTip {
         return gravity;
     }
 
-    public Spannable getSpannableMessage() {
-        return mSpannableMessage;
-    }
-
     public static class Builder {
-        private Context mContext;
-        private View mAnchorView;
-        private ViewGroup mRootViewGroup;
-        private String mMessage;
+        private @NonNull Context mContext;
+        private @NonNull View mAnchorView;
+        private @NonNull ViewGroup mRootViewGroup;
+        private @NonNull CharSequence mMessage;
         private @Position int mPosition;
         private @Align int mAlign;
         private int mOffsetX;
@@ -207,25 +206,28 @@ public class ToolTip {
         private int mBackgroundColor;
         private float mElevation;
         private @Gravity int mTextGravity;
-        private Spannable mSpannableMessage;
         private @StyleRes int mTextAppearanceStyle;
-        private Typeface mTypeface;
+        private @Nullable Typeface mTypeface;
 
 
         /**
+         * Creates the tooltip builder with message and required parameters to show tooltip.
          *
          * @param context context
          * @param anchorView the view which near it we want to put the tip
          * @param root a class extends ViewGroup which the created tip view will be added to
-         * @param message message to show
-         * @param position  put the tip above / below / left to / right to
+         * @param message message to show. Note: This allows normal text and spannable text with spanned styles.
+         * @param position  put the tip above / below / left to / right to anchor view.
          */
-        public Builder(Context context, View anchorView, ViewGroup root, String message, @Position int position){
+        public Builder(@NonNull Context context,
+                       @NonNull View anchorView,
+                       @NonNull ViewGroup root,
+                       @NonNull CharSequence message,
+                       @Position int position) {
             mContext = context;
             mAnchorView = anchorView;
             mRootViewGroup = root;
             mMessage = message;
-            mSpannableMessage = null;
             mPosition = position;
             mAlign = ALIGN_CENTER;
             mOffsetX = 0;
@@ -236,34 +238,13 @@ public class ToolTip {
             mTextAppearanceStyle = R.style.TooltipDefaultStyle;
         }
 
-        /**
-         * @param context    context
-         * @param anchorView the view which near it we want to put the tip
-         * @param root       a class extends ViewGroup which the created tip view will be added to
-         * @param message    spannable message to show
-         * @param position   put the tip above / below / left to / right to
-         */
-        public Builder(Context context, View anchorView, ViewGroup root, Spannable message, @Position int position) {
-            mContext = context;
-            mAnchorView = anchorView;
-            mRootViewGroup = root;
-            mMessage = null;
-            mSpannableMessage = message;
-            mPosition = position;
-            mAlign = ALIGN_CENTER;
-            mOffsetX = 0;
-            mOffsetY = 0;
-            mArrow = true;
-            mBackgroundColor = context.getResources().getColor(R.color.colorBackground);
-            mTextGravity = GRAVITY_LEFT;
-            mTextAppearanceStyle = R.style.TooltipDefaultStyle;
-        }
-
+        @NonNull
         public Builder setPosition(@Position int position){
             mPosition = position;
             return this;
         }
 
+        @NonNull
         public Builder setAlign(@Align int align){
             mAlign = align;
             return this;
@@ -273,6 +254,7 @@ public class ToolTip {
          * @param offset offset to move the tip on x axis after tip was positioned
          * @return offset
          */
+        @NonNull
         public Builder setOffsetX(int offset){
             mOffsetX = offset;
             return this;
@@ -282,41 +264,49 @@ public class ToolTip {
          * @param offset offset to move the tip on y axis after tip was positioned
          * @return offset
          */
+        @NonNull
         public Builder setOffsetY(int offset){
             mOffsetY = offset;
             return this;
         }
 
+        @NonNull
         public Builder withArrow(boolean value){
             mArrow = value;
             return this;
         }
 
+        @NonNull
         public Builder setBackgroundColor(int color){
             mBackgroundColor = color;
             return this;
         }
 
+        @NonNull
         public Builder setElevation(float elevation){
             mElevation = elevation;
             return this;
         }
 
+        @NonNull
         public Builder setGravity(@Gravity int gravity){
             mTextGravity = gravity;
             return this;
         }
 
+        @NonNull
         public Builder setTextAppearance(@StyleRes int textAppearance) {
             mTextAppearanceStyle = textAppearance;
             return this;
         }
 
-        public Builder setTypeface(Typeface typeface) {
+        @NonNull
+        public Builder setTypeface(@NonNull Typeface typeface) {
             mTypeface = typeface;
             return this;
         }
 
+        @NonNull
         public ToolTip build(){
             return new ToolTip(this);
         }

--- a/tooltips/src/main/java/com/tomergoldst/tooltips/ToolTipsManager.java
+++ b/tooltips/src/main/java/com/tomergoldst/tooltips/ToolTipsManager.java
@@ -139,7 +139,7 @@ public class ToolTipsManager {
     @NonNull
     private TextView createTipView(ToolTip toolTip) {
         TextView tipView = new TextView(toolTip.getContext());
-        tipView.setText(toolTip.getMessage() != null ? toolTip.getMessage() : toolTip.getSpannableMessage());
+        tipView.setText(toolTip.getMessage());
         tipView.setVisibility(View.INVISIBLE);
         tipView.setGravity(toolTip.getTextGravity());
         tipView.setTextAppearance(toolTip.getContext(), toolTip.getTextAppearanceStyle());


### PR DESCRIPTION
Cleanup API to allow user to use the spannable text. Updated sample app with usage.

## Changelog
- [UPDATE] Use `ToolTip.Builder()` with `CharSequence` message that is more inclusive than `String` and `Spannable`.
- [REMOVED] Redundant `ToolTip.Builder()` with `Spannable` message after the API update, and updated code accordingly.
- [ADDED] First time tooltip message with span to showcase the possibility.
- [ADDED] `@Nullable` and `@NonNull` to be future proof _(kotlin tsk tsk)_.

## Screenshot

### API 26
![device-2018-04-01-141512](https://user-images.githubusercontent.com/99822/38176334-cd6d973a-35ba-11e8-9f36-85f2f05e983d.png)

NOTE: This is an extension of #1 

### API 16
![screenshot_1522607356](https://user-images.githubusercontent.com/99822/38176329-bb3a7c90-35ba-11e8-893f-01e0995f4ae5.png)

### Reference Usage - Google+ App
![device-2018-04-01-135626](https://user-images.githubusercontent.com/99822/38176331-c5e5415c-35ba-11e8-8cb6-1031e0b0c44f.png)

